### PR TITLE
removing logging for gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ CMD ["./gnmi-gateway", \
     "-TargetLoaders=json", \
     "-TargetJSONFile=./targets.json", \
     "-EnableGNMIServer", \
-    "-Exporters=debug", \ 
     "-OpenConfigDirectory=./oc-models/", \ 
     "-ServerTLSCert=server.crt", \
     "-ServerTLSKey=server.key"]


### PR DESCRIPTION
removing logging for gnmi-gateway which was taking large space

Adding test logs of docker build and installation here
[test_logs.txt](https://github.com/AvizNetworks/gnmi-gateway/files/10465087/test_logs.txt)
